### PR TITLE
Refactor email sending to be asynchronous

### DIFF
--- a/Functions/EmailSender.cs
+++ b/Functions/EmailSender.cs
@@ -26,7 +26,8 @@ public class EmailSender
             var emailRequest = _emailService.UnpackEmailRequest(message);
             if (emailRequest != null && !string.IsNullOrEmpty(emailRequest.To))
             {
-                if (_emailService.SendEmail(emailRequest))
+                var result = await _emailService.SendEmailAsync(emailRequest);
+                if (result)
                 {
                     await messageActions.CompleteMessageAsync(message);
                 }

--- a/Services/EmailService.cs
+++ b/Services/EmailService.cs
@@ -7,10 +7,16 @@ using Newtonsoft.Json;
 
 
 namespace EmailProvider.Services;
-public class EmailService(EmailClient emailClient, ILogger<EmailService> logger) : IEmailService
+public class EmailService : IEmailService
 {
-    private readonly EmailClient _emailClient = emailClient;
-    private readonly ILogger<EmailService> _logger = logger;
+    private readonly EmailClient _emailClient;
+    private readonly ILogger<EmailService> _logger;
+
+    public EmailService(EmailClient emailClient, ILogger<EmailService> logger)
+    {
+        _emailClient = emailClient;
+        _logger = logger;
+    }
 
     public EmailRequest UnpackEmailRequest(ServiceBusReceivedMessage message)
     {
@@ -29,33 +35,39 @@ public class EmailService(EmailClient emailClient, ILogger<EmailService> logger)
         return null!;
     }
 
-    public bool SendEmail(EmailRequest emailRequest)
+    public async Task<bool> SendEmailAsync(EmailRequest emailRequest)
     {
-        if (emailRequest.Subject != null && emailRequest.To != null) 
+        if (emailRequest.Subject != null && emailRequest.To != null)
         {
             try
             {
-                var result = _emailClient.Send(
-            WaitUntil.Completed,
+                _logger.LogInformation($"Sending email to {emailRequest.To} with subject {emailRequest.Subject}, HTMLBODY: {emailRequest.HtmlBody} och PLAINTEXT:{emailRequest.PlainText}");
 
-                senderAddress: Environment.GetEnvironmentVariable("SenderAddress"),
-                recipientAddress: emailRequest.To,
-                subject: emailRequest.Subject,
-                htmlContent: emailRequest.HtmlBody,
-                plainTextContent: emailRequest.PlainText);
+                EmailSendOperation result = await _emailClient.SendAsync(
+                    Azure.WaitUntil.Completed,
+                    senderAddress: Environment.GetEnvironmentVariable("SenderAddress"),
+                    recipientAddress: emailRequest.To,
+                    subject: emailRequest.Subject,
+                    htmlContent: emailRequest.HtmlBody,
+                    plainTextContent: emailRequest.PlainText);
+                EmailSendResult statusMonitor = result.Value;
 
+                _logger.LogInformation($"Email Sent. Status = {result.Value.Status}");
+                string operationId = result.Id;
+                _logger.LogInformation($"Email operation id = {operationId}");
+            
+            
                 if (result.HasCompleted)
                 {
                     return true;
                 }
             }
-
             catch (Exception ex)
             {
                 _logger.LogError($"ERROR : EmailSender.SendEmail() :: {ex.Message}");
             }
         }
-       
+
         return false;
     }
 }

--- a/Services/IEmailService.cs
+++ b/Services/IEmailService.cs
@@ -4,6 +4,6 @@ using EmailProvider.Models;
 namespace EmailProvider.Services;
 public interface IEmailService
 {
-    bool SendEmail(EmailRequest emailRequest);
+    Task<bool> SendEmailAsync(EmailRequest emailRequest);
     EmailRequest UnpackEmailRequest(ServiceBusReceivedMessage message);
 }


### PR DESCRIPTION
Refactored `EmailSender` and `EmailService` to use asynchronous methods for sending emails. Updated `EmailSender` to call `SendEmailAsync` and await the result. Modified `EmailService` to use dependency injection, renamed `SendEmail` to `SendEmailAsync`, and added detailed logging. Updated `IEmailService` interface to reflect these changes.